### PR TITLE
Change SmartMeterLanguage  -> Smart Message Language

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ ioBroker-Forum-Thread: http://forum.iobroker.net/viewtopic.php?f=23&t=5047&p=549
 
 ### Data Protocol
 Supported Protocols:
-* **Sml**: SML (SmartMeterLanguage) as binary format
+* **Sml**: SML (Smart Message Language) as binary format
 * **D0**: D0 (based on IEC 62056-21:2002/IEC 61107/EN 61107) as ASCII format (binary protocol mode E not supported currently)
 * **Json-Efr**: OBIS data from EFR Smart Grid Hub (JSON format)
 

--- a/admin/words.js
+++ b/admin/words.js
@@ -11,7 +11,7 @@ systemDictionary = {
     "field_protocol":   {"en": "Data Protocol", "de": "Daten-Protokoll"},
     "value_protocol_D0Protocol":   {"en": "D0 (WakeUp, SignOn, Data)", "de": "D0 (WakeUp, SignOn, Data)"},
     "value_protocol_JsonEfrProtocol":   {"en": "JSON-Format EFR SmartGridHub", "de": "JSON-Format EFR SmartGridHub"},
-    "value_protocol_SmlProtocol":   {"en": "SmartMeterLanguage 1.0.3", "de": "SmartMeterLanguage 1.0.3"},
+    "value_protocol_SmlProtocol":   {"en": "Smart Message Language 1.0.3", "de": "Smart Message Language 1.0.3"},
     "info_protocol":   {"en": " ", "de": " "},
 
     "field_transport":   {"en": "Data Transfer", "de": "Datenübertragung"},


### PR DESCRIPTION
The Abbreviation SML is referenced as SmartMeterLanguage in this project. Official Name is Smart Message Language

2 files are affected with 3 occurences in total