### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Windows: [![AppVeyor](https://ci.appveyor.com/api/projects/status/github/Apollon
 
 This adapter for ioBroker allows the reading and parsing of smartmeter protocols that follow the OBIS number logic to make their data available.
 
-***The Adapter needs nodejs 4.x to work!***
+***The Adapter needs nodejs 8.x+ to work!***
 
 ***This Adapter needs to have git installed currently for installing!***
 


### PR DESCRIPTION
According to https://github.com/Apollon77/ioBroker.smartmeter#301-2019-11-27 the necessary nodejs version is 8.x+